### PR TITLE
Handle case where proxy service returns no proxies or returns invalid ...

### DIFF
--- a/login/login.ts
+++ b/login/login.ts
@@ -170,7 +170,11 @@ module Login {
         options.type = 'GET';
         options.contentType = 'application/json; charset=utf-8';
         options.success = result => {
-            finishConnect(result.address, result.port.toString(), character);
+            if (result && result.address && result.port) {
+                finishConnect(result.address, result.port.toString(), character);
+            } else {
+                showModal(createErrorModal('Invalid or missing proxy'));
+            }
         };
         options.error = (xhr, status, err) => {
             showModal(createErrorModal(err));


### PR DESCRIPTION
...proxy details.

The proxy REST API can return an empty proxy list.  In the JSON case it is returning no JSON data and the result from XHR is null.

Handle both null result and missing proxy details.