### PR TITLE
Fix an issue with drawing the server list when the response from the list server is not recognized or empty.

### DIFF
--- a/login/login.ts
+++ b/login/login.ts
@@ -236,13 +236,15 @@ module Login {
 
         $tbody.empty();
 
-        servers.forEach((server) => {
-            var row = createServerModalRow(server);
+        if (servers) {
+            servers.forEach((server) => {
+                var row = createServerModalRow(server);
 
-            row.$row.appendTo($tbody);
+                row.$row.appendTo($tbody);
 
-            updateServerEntry(server, row);
-        });
+                updateServerEntry(server, row);
+            });
+        }
     }
 
     function createServersModal() {


### PR DESCRIPTION
Fixes the following error:

Uncaught TypeError: Cannot read property 'forEach' of null, source: cu-ui/login/login.js (246)