### PR TITLE
Allow ability-builder to be shown a second time.  

### DIFF
--- a/ability-builder/builder.ts
+++ b/ability-builder/builder.ts
@@ -808,6 +808,9 @@ module AbilityBuilder {
         $builder.fadeOut(() => {
             if (typeof cuAPI === 'object') {
                 cuAPI.HideUI('ability-builder');
+                setTimeout(() => {
+                    $builder.css({ display: 'block' });
+                }, 100);
             }
         });
 


### PR DESCRIPTION
After fading and hiding the UI, set it to display: block so that it is visible again on show.