### PR TITLE
Allow spellbook to be re-opened.  

### DIFF
--- a/spellbook/spellbook.ts
+++ b/spellbook/spellbook.ts
@@ -994,6 +994,9 @@ module Spellbook {
         $spellbook.fadeOut(() => {
             if (typeof cuAPI === 'object') {
                 cuAPI.HideUI('spellbook');
+                setTimeout(() => {
+                    $spellbook.css({ display: 'block' });
+                }, 100);
             }
         });
 


### PR DESCRIPTION
After fading and hiding the view, set it to display: block so it is visible next time it is shown.