### PR TITLE
Fix "X" close button on gamemenu.

### DIFF
--- a/gamemenu/gamemenu.ts
+++ b/gamemenu/gamemenu.ts
@@ -12,7 +12,7 @@ module GameMenu {
         cuAPI.Quit();
     });
 
-    $('window-close').click(() => {
+    $('.window-close').click(() => {
         cuAPI.CloseUI('gamemenu');
     });
 


### PR DESCRIPTION
The click event-handler wasn't binding anywhere due to a a typo in the jQuery selector.