### PR TITLE
Fix grunt-ts

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -23,27 +23,19 @@ module.exports = function (grunt) {
         },
 
         ts: {
-
+            options: {
+                failOnTypeErrors: false
+            },
             dev: {
-                src: ['**/*.ts', '!node_modules/**', '!.tscache/**'],
-                vs: {
-                    project: 'UI.csproj',
-                    config: 'Debug',
-                    ignoreFiles: true
-                }
+                src: ['**/*.ts', '!node_modules/**', '!.tscache/**']
             },
-
             debug: {
-                vs: {
-                    project: 'UI.csproj',
-                    config: 'Debug'
-                }
+                src: ['**/*.ts', '!node_modules/**', '!.tscache/**']
             },
-
             release: {
-                vs: {
-                    project: 'UI.csproj',
-                    config: 'Release'
+                src: ['**/*.ts', '!node_modules/**', '!.tscache/**'],
+                options: {
+                    sourceMap: false
                 }
             }
         },


### PR DESCRIPTION
Have fixed issues with the previous `VS` configuration for `grunt-ts` as it was not compiling any `ts` files to `js`.

Also set `"failOnTypeErrors"` to `false` to prevent tasks failing on `non-emit-breaking` errors.