### PR TITLE
Added installation of TypeScript definitions to build:install

### DIFF
--- a/build.js
+++ b/build.js
@@ -27,6 +27,17 @@ function installModule(directory) {
   cd('..');
 }
 
+function runTypings(directory) {
+  fs.access(path.join(directory, '/typings.json'), fs.R_OK, function(err) {
+    if(err === null) {
+      console.log(chalk.green(`running typings install in ${directory}`));
+      cd(directory);
+      exec('typings install');  
+      cd('..');
+    }  
+  });
+}
+
 function buildModule(directory) {
   console.log(chalk.green(`building module at ${directory}`));
   cd(directory);
@@ -36,5 +47,10 @@ function buildModule(directory) {
 }
 
 var directories = getDirectories('.');
-if (yargs.install) directories.map(installModule);
+
+if (yargs.install) {
+    directories.map(installModule);
+    directories.map(runTypings)
+}
+
 if (yargs.build) directories.map(buildModule);


### PR DESCRIPTION
Added installation of TypeScript definitions to build:install. The command "typings install" will be run in each module that contains a
typings.json file.

If you prefer I could make it available via a separate option like build:typings instead of folding it into build:install, but to me it doesn't seem out of place where it is now.