### PR TITLE
Adding simple CSS tooltips to Inventory and EquippedGear

### DIFF
--- a/equippedgear/package.json
+++ b/equippedgear/package.json
@@ -61,7 +61,6 @@
     "bourbon": "^4.2.6",
     "camelot-unchained": "^0.2.5",
     "classnames": "^2.2.1",
-    "rc-tooltip": "^3.3.0",
     "react": "^0.14.3",
     "react-dom": "^0.14.3"
   },

--- a/equippedgear/src/equippedgear.ui
+++ b/equippedgear/src/equippedgear.ui
@@ -2,10 +2,10 @@
   "name": "equippedgear",
   "mainFile": "index.html",
   "rect": {
-    "left": 810,
+    "left": 600,
     "top": 350,
     "right": 1120,
-    "bottom": 770
+    "bottom": 700
   },
   "handlesAbilities": false,
   "handlesAnnouncements": false,

--- a/equippedgear/src/equippedgear.ui
+++ b/equippedgear/src/equippedgear.ui
@@ -2,7 +2,7 @@
   "name": "equippedgear",
   "mainFile": "index.html",
   "rect": {
-    "left": 600,
+    "left": 640,
     "top": 350,
     "right": 1120,
     "bottom": 700

--- a/equippedgear/src/sass/equippedgear.scss
+++ b/equippedgear/src/sass/equippedgear.scss
@@ -32,7 +32,21 @@
   list-style: none;
 }
 
-.equippedgear-list__item {
+.equippedgear-title {
+  margin: 5px 0 0;
+  cursor: default;
+  text-align: center;
+  
+  &:first-child {
+    margin: 0px;
+  }
+
+  &:hover {
+    background-color: rgba(0,0,0,0);
+  }
+}
+
+.equippedgear-item {
   margin: 0;
   padding: 4px 2px 4px 4px;
   text-shadow: -1px -1px 1px #000, 1px -1px 1px #000, -1px 1px 1px #000, 1px 1px 1px #000;
@@ -45,20 +59,6 @@
     overflow: hidden;
     cursor: pointer;
     margin-bottom: 10px;
-
-    &.gear-slot-title {
-      margin: 5px 0 0;
-      cursor: default;
-      text-align: center;
-      
-      &:first-child {
-        margin: 0px;
-      }
-
-      &:hover {
-        background-color: rgba(0,0,0,0);
-      }
-    }
 
     &:last-child {
       margin-bottom: 10px;
@@ -114,7 +114,7 @@
   box-shadow: 0 0 0 3px rgba(0, 0, 0, .45);
   pointer-events: none;
 
-  .inventory-item:hover & {
+  .equippedgear-item:hover & {
     display: block;
   }
 }

--- a/equippedgear/src/sass/equippedgear.scss
+++ b/equippedgear/src/sass/equippedgear.scss
@@ -8,8 +8,11 @@
  @import "../../node_modules/camelot-unchained/lib/index.scss";
 
 #equippedgear {
-  width: 273px;
-  height: 336px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 203px;
 }
 
 .cu-window-content::before {
@@ -18,62 +21,69 @@
 
 .equippedgear-list {
   overflow: auto;
-  height: calc(100% - 50px);
+  position: absolute;
+  top: 0;
+  right: 9px;
+  bottom: 8px;
+  left: 10px;
+  z-index: 2;
+  margin: 0;
+  padding: 4px 2px 0 5px;
   list-style: none;
-  padding-left: 5px;
-  padding-right: 2px;
-  padding-bottom: 0px;
-  padding-top: 4px;
-  li {
-    margin-bottom: 0px;
-    padding-left: 4px;
-    padding-right: 2px;
-    padding-top: 4px;
-    padding-bottom: 4px;
-    text-shadow: -1px -1px 1px #000, 1px -1px 1px #000, -1px 1px 1px #000, 1px 1px 1px #000;
-    &:hover {
-      background-color: rgba(0,0,0,0.5);
-    }
+}
+
+.equippedgear-list__item {
+  margin: 0;
+  padding: 4px 2px 4px 4px;
+  text-shadow: -1px -1px 1px #000, 1px -1px 1px #000, -1px 1px 1px #000, 1px 1px 1px #000;
+  
+  &:hover {
+    background-color: rgba(0,0,0,0.75);
   }
 
-  &.list-vertical {
-    li {
-      overflow: hidden;
-      cursor: pointer;
+  .equippedgear-list--vertical & {
+    overflow: hidden;
+    cursor: pointer;
+    margin-bottom: 10px;
+
+    &.gear-slot-title {
+      margin: 5px 0 0;
+      cursor: default;
+      text-align: center;
+      
+      &:first-child {
+        margin: 0px;
+      }
+
+      &:hover {
+        background-color: rgba(0,0,0,0);
+      }
+    }
+
+    &:last-child {
       margin-bottom: 10px;
-      &.gear-slot-title {
-        cursor:default;
-        margin-top: 5px;
-        text-align: center;
-        margin-bottom: 0px;
-        &:first-child {
-          margin-top: 0px;
-        }
-        &:hover {
-          background-color: rgba(0,0,0,0);
-        }
-      }
-      &:last-child {
-        margin-bottom: 10px;
-      }
-      .icon {
+    }
+
+    .icon {
+      display: inline-block;
+      vertical-align: middle;
+      margin-top: -1px;
+
+      img {
         display: block;
-        float: left;
-        img {
-          display: block;
-        }
       }
-      .name {
-        display: block;
-        float: left;
-        line-height: 15px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        max-width: 190px;
-        padding-left: 5px;
-        font-size: 80%;
-      }
+    }
+
+    .name {
+      display: inline-block;
+      vertical-align: middle;
+      max-width: 190px;
+      padding-left: 5px;
+      line-height: 15px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-size: 80%;
     }
   }
 }
@@ -90,36 +100,40 @@
   -webkit-box-shadow: inset 0 0 10px #000;
 }
 
-.tooltip-content {
-  width: 230px;
-  tr {
-    font-size: 80%;
-    vertical-align: top;
-    border-bottom: 1px dashed #222;
-    &:last-child {
-      border-bottom: none;
-    }
-  }
-  th {
-    padding-right: 5px;
-    border-right: 1px dashed #222;
-    padding-bottom: 2px;
-    padding-top: 2px;
-  }
-  td {
-    padding-left: 5px;
-    padding-bottom: 2px;
-    padding-top: 2px;
-    word-break: break-word;
-    &.font-small {
-      font-size: 9px;
-    }
-    &.font-monospace {
-      font-family: 'Roboto Mono', monospace;
-    }
+.tooltip {
+  display: none;
+  position: fixed;
+  top: 47px; // magic number to place under header
+  left: 3px; // allow shadow to fit on left size of rect
+  z-index: 2;
+  width: 204px;
+  padding: 10px;
+  border: 1px solid #555;
+  background: rgba(0, 0, 0, .75);
+  color: #ccc;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, .45);
+  pointer-events: none;
+
+  .inventory-item:hover & {
+    display: block;
   }
 }
 
-.cu-tooltip-inner {
-  padding: 2px 6px !important;
+.tooltip__title {
+  margin: 0 0 3px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.tooltip__detail {
+  margin: 0 0 4px;
+  font-size: 10px;
+}
+
+.tooltip__meta {
+  margin: 0;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 9px;
+  color: #999;
 }

--- a/equippedgear/src/ts/components/equippedgear-window.tsx
+++ b/equippedgear/src/ts/components/equippedgear-window.tsx
@@ -7,7 +7,6 @@
 import * as React from 'react';
 import {client, events, EquippedGear, Item, gearSlot} from 'camelot-unchained';
 import ClassNames from 'classnames';
-// import Tooltip from 'rc-tooltip';
 
 export class EquippedGearWindow extends React.Component<EquippedGearWindowProps, EquippedGearWindowState> {
   private listener: any;
@@ -56,9 +55,15 @@ export class EquippedGearWindow extends React.Component<EquippedGearWindowProps,
           <li key={'gear-slot'+index} className="gear-slot-title cu-font-cinzel">{this.getGearSlotName(slotId)}</li>
         ));
         items.push((
-          <li key={'item'+index} onDoubleClick={this.unequipItem.bind(this, item)} onContextMenu={this.unequipItem.bind(this, item)}>
+          <li class="equippedgear-item" key={'item'+index} onDoubleClick={this.unequipItem.bind(this, item)} onContextMenu={this.unequipItem.bind(this, item)}>
             <div className="icon"><img src="../../interface-lib/camelot-unchained/images/items/icon.png" /></div>
             <div className="name">{item.name}</div>
+            <div className="tooltip">
+              <h1 className="tooltip__title">{item.name}</h1>
+              <p className="tooltip__detail tooltip__slot">{this.getGearSlotName(item.gearSlot)}</p>
+              <p className="tooltip__detail tooltip__description">{item.description}</p>
+              <p className="tooltip__meta">Resource ID: {item.id}</p>
+            </div>
           </li>
         ))
       }
@@ -72,42 +77,13 @@ export class EquippedGearWindow extends React.Component<EquippedGearWindowProps,
           </div>
         </div>
         <div className="cu-window-content">
-          <ul className="equippedgear-list list-vertical">
+          <ul className="equippedgear-list equippedgear-list--vertical">
             {items}
           </ul>
         </div>
       </div>
     );
   }
-
-  // renderTooltip(item: Item) {
-  //   return (
-  //     <table className="cu-table tooltip-content">
-  //       <tbody>
-  //         <tr>
-  //           <th>Name</th>
-  //           <td>{item.name}</td>
-  //         </tr>
-  //         <tr>
-  //           <th>Description</th>
-  //           <td>{item.description}</td>
-  //         </tr>
-  //         <tr>
-  //           <th>Gear Slot</th>
-  //           <td>{this.getGearSlotName(item.gearSlot)} ({item.gearSlot})</td>
-  //         </tr>
-  //         <tr>
-  //           <th>Item ID</th>
-  //           <td className="font-monospace font-small">{item.id}</td>
-  //         </tr>
-  //         <tr>
-  //           <th>Resource ID</th>
-  //           <td className="font-monospace">{item.resourceID}</td>
-  //         </tr>
-  //       </tbody>
-  //     </table>
-  //   );
-  // }
 
   getGearSlotName(slot: any): string {
     switch (parseInt(slot, 10)) {

--- a/equippedgear/src/ts/components/equippedgear-window.tsx
+++ b/equippedgear/src/ts/components/equippedgear-window.tsx
@@ -7,7 +7,7 @@
 import * as React from 'react';
 import {client, events, EquippedGear, Item, gearSlot} from 'camelot-unchained';
 import ClassNames from 'classnames';
-import Tooltip from 'rc-tooltip';
+// import Tooltip from 'rc-tooltip';
 
 export class EquippedGearWindow extends React.Component<EquippedGearWindowProps, EquippedGearWindowState> {
   private listener: any;
@@ -56,12 +56,10 @@ export class EquippedGearWindow extends React.Component<EquippedGearWindowProps,
           <li key={'gear-slot'+index} className="gear-slot-title cu-font-cinzel">{this.getGearSlotName(slotId)}</li>
         ));
         items.push((
-          <Tooltip placement="topLeft" key={'item-tooltip' + index} overlay={this.renderTooltip.call(this, item)} arrowContent={<div className="cu-tooltip-arrow-inner"></div>} prefixCls="cu-tooltip" mouseLeaveDelay={0} mouseEnterDelay={0.25}>
-            <li key={'item'+index} onDoubleClick={this.unequipItem.bind(this, item)} onContextMenu={this.unequipItem.bind(this, item)}>
-              <div className="icon"><img src="../../interface-lib/camelot-unchained/images/items/icon.png" /></div>
-              <div className="name">{item.name}</div>
-            </li>
-          </Tooltip>
+          <li key={'item'+index} onDoubleClick={this.unequipItem.bind(this, item)} onContextMenu={this.unequipItem.bind(this, item)}>
+            <div className="icon"><img src="../../interface-lib/camelot-unchained/images/items/icon.png" /></div>
+            <div className="name">{item.name}</div>
+          </li>
         ))
       }
     });
@@ -82,34 +80,34 @@ export class EquippedGearWindow extends React.Component<EquippedGearWindowProps,
     );
   }
 
-  renderTooltip(item: Item) {
-    return (
-      <table className="cu-table tooltip-content">
-        <tbody>
-          <tr>
-            <th>Name</th>
-            <td>{item.name}</td>
-          </tr>
-          <tr>
-            <th>Description</th>
-            <td>{item.description}</td>
-          </tr>
-          <tr>
-            <th>Gear Slot</th>
-            <td>{this.getGearSlotName(item.gearSlot)} ({item.gearSlot})</td>
-          </tr>
-          <tr>
-            <th>Item ID</th>
-            <td className="font-monospace font-small">{item.id}</td>
-          </tr>
-          <tr>
-            <th>Resource ID</th>
-            <td className="font-monospace">{item.resourceID}</td>
-          </tr>
-        </tbody>
-      </table>
-    );
-  }
+  // renderTooltip(item: Item) {
+  //   return (
+  //     <table className="cu-table tooltip-content">
+  //       <tbody>
+  //         <tr>
+  //           <th>Name</th>
+  //           <td>{item.name}</td>
+  //         </tr>
+  //         <tr>
+  //           <th>Description</th>
+  //           <td>{item.description}</td>
+  //         </tr>
+  //         <tr>
+  //           <th>Gear Slot</th>
+  //           <td>{this.getGearSlotName(item.gearSlot)} ({item.gearSlot})</td>
+  //         </tr>
+  //         <tr>
+  //           <th>Item ID</th>
+  //           <td className="font-monospace font-small">{item.id}</td>
+  //         </tr>
+  //         <tr>
+  //           <th>Resource ID</th>
+  //           <td className="font-monospace">{item.resourceID}</td>
+  //         </tr>
+  //       </tbody>
+  //     </table>
+  //   );
+  // }
 
   getGearSlotName(slot: any): string {
     switch (parseInt(slot, 10)) {

--- a/equippedgear/src/ts/components/equippedgear-window.tsx
+++ b/equippedgear/src/ts/components/equippedgear-window.tsx
@@ -52,7 +52,7 @@ export class EquippedGearWindow extends React.Component<EquippedGearWindowProps,
       const item = this.state.equippedgear.getItemInGearSlot(slotId);
       if (item != null) {
         items.push((
-          <li key={'gear-slot'+index} className="gear-slot-title cu-font-cinzel">{this.getGearSlotName(slotId)}</li>
+          <li key={'gear-slot'+index} className="equippedgear-title cu-font-cinzel">{this.getGearSlotName(slotId)}</li>
         ));
         items.push((
           <li className="equippedgear-item" key={'item'+index} onDoubleClick={this.unequipItem.bind(this, item)} onContextMenu={this.unequipItem.bind(this, item)}>

--- a/equippedgear/src/ts/components/equippedgear-window.tsx
+++ b/equippedgear/src/ts/components/equippedgear-window.tsx
@@ -55,7 +55,7 @@ export class EquippedGearWindow extends React.Component<EquippedGearWindowProps,
           <li key={'gear-slot'+index} className="gear-slot-title cu-font-cinzel">{this.getGearSlotName(slotId)}</li>
         ));
         items.push((
-          <li class="equippedgear-item" key={'item'+index} onDoubleClick={this.unequipItem.bind(this, item)} onContextMenu={this.unequipItem.bind(this, item)}>
+          <li className="equippedgear-item" key={'item'+index} onDoubleClick={this.unequipItem.bind(this, item)} onContextMenu={this.unequipItem.bind(this, item)}>
             <div className="icon"><img src="../../interface-lib/camelot-unchained/images/items/icon.png" /></div>
             <div className="name">{item.name}</div>
             <div className="tooltip">

--- a/inventory/package.json
+++ b/inventory/package.json
@@ -60,10 +60,9 @@
   "dependencies": {
     "camelot-unchained": "latest",
     "classnames": "^2.2.1",
-    "rc-tooltip": "^3.3.0",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
-	"es6-promise": "^3.0.0"
+  	"es6-promise": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",

--- a/inventory/src/inventory.ui
+++ b/inventory/src/inventory.ui
@@ -2,7 +2,7 @@
   "name": "inventory",
   "mainFile": "index.html",
   "rect": {
-    "left": 1120,
+    "left": 900,
     "top": 350,
     "right": 1430,
     "bottom": 770

--- a/inventory/src/inventory.ui
+++ b/inventory/src/inventory.ui
@@ -2,10 +2,10 @@
   "name": "inventory",
   "mainFile": "index.html",
   "rect": {
-    "left": 900,
+    "left": 950,
     "top": 350,
     "right": 1430,
-    "bottom": 770
+    "bottom": 700
   },
   "handlesAbilities": false,
   "handlesAnnouncements": false,

--- a/inventory/src/sass/inventory.scss
+++ b/inventory/src/sass/inventory.scss
@@ -12,7 +12,7 @@
   top: 0;
   right: 0;
   bottom: 0;
-  left: 250px;
+  left: 203px;
 }
 
 .cu-window-content::before {
@@ -95,10 +95,10 @@
 .tooltip {
   display: none;
   position: fixed;
-  top: 42px; // magic number to place under header
+  top: 43px; // magic number to place under header
   left: 0;
   z-index: 2;
-  width: 250px;
+  width: 210px;
   padding: 10px;
   border: 1px solid #555;
   background: rgba(0, 0, 0, .75);
@@ -125,9 +125,10 @@
 }
 
 .tooltip__meta {
-  color: #999;
+  margin: 0;
   font-family: 'Roboto Mono', monospace;
   font-size: 9px;
+  color: #999;
 }
 
 .cu-tooltip-inner {

--- a/inventory/src/sass/inventory.scss
+++ b/inventory/src/sass/inventory.scss
@@ -92,9 +92,15 @@
 .tooltip {
   display: none;
   position: absolute;
-  top: 100%;
+  bottom: 100%;
   left: 0;
+  z-index: 2;
   width: 100%;
+  padding: 10px;
+  border: 1px solid #555;
+  background: rgba(0, 0, 0, .75);
+  color: #ccc;
+  box-shadow: 0 0 0 0 3px rgba(0, 0, 0, .45);
   pointer-events: none;
 
   .inventory-item:hover & {
@@ -102,36 +108,16 @@
   }
 }
 
-.tooltip__content {
-  width: 100%;
+.tooltip__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+}
 
-  tr {
-    font-size: 80%;
-    vertical-align: top;
-    border-bottom: 1px dashed #222;
-
-    &:last-child {
-      border-bottom: none;
-    }
-  }
-
-  th {
-    padding: 2px 5px 2px 0;
-    border-right: 1px dashed #222;
-  }
-
-  td {
-    padding: 2px 0 2px 5px;
-    word-break: break-word;
-
-    &.font-small {
-      font-size: 9px;
-    }
-
-    &.font-monospace {
-      font-family: 'Roboto Mono', monospace;
-    }
-  }
+.tooltip__meta {
+  color: #999;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 9px;
 }
 
 .cu-tooltip-inner {

--- a/inventory/src/sass/inventory.scss
+++ b/inventory/src/sass/inventory.scss
@@ -20,9 +20,10 @@
   overflow: auto;
   position: absolute;
   top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  right: 9px;
+  bottom: 8px;
+  left: 10px;
+  z-index: 2;
   margin: 0;
   padding: 4px 2px 0 5px;
   list-style: none;
@@ -91,9 +92,9 @@
 .tooltip {
   display: none;
   position: absolute;
-  top: 0;
+  top: 100%;
   left: 0;
-  width: 230px;
+  width: 100%;
   pointer-events: none;
 
   .inventory-item:hover & {

--- a/inventory/src/sass/inventory.scss
+++ b/inventory/src/sass/inventory.scss
@@ -95,10 +95,10 @@
 .tooltip {
   display: none;
   position: fixed;
-  top: 43px; // magic number to place under header
+  top: 47px; // magic number to place under header
   left: 3px; // allow shadow to fit on left size of rect
   z-index: 2;
-  width: 207px;
+  width: 204px;
   padding: 10px;
   border: 1px solid #555;
   background: rgba(0, 0, 0, .75);

--- a/inventory/src/sass/inventory.scss
+++ b/inventory/src/sass/inventory.scss
@@ -39,12 +39,12 @@
   }
 
   .inventory-list--vertical & {
-    overflow: hidden;
     cursor: pointer;
 
     .icon {
-      display: block;
-      float: left;
+      display: inline-block;
+      vertical-align: middle;
+      margin-top: -1px;
 
       img {
         display: block;
@@ -52,8 +52,8 @@
     }
 
     .name {
-      display: block;
-      float: left;
+      display: inline-block;
+      vertical-align: middle;
       max-width: 190px;
       padding-left: 5px;
       line-height: 15px;
@@ -66,6 +66,7 @@
     .quantity {
       display: block;
       float: right;
+      margin: 1px 0 0;
       padding: 0 2px 0 5px;
       line-height: 15px;
       font-size: 80%;

--- a/inventory/src/sass/inventory.scss
+++ b/inventory/src/sass/inventory.scss
@@ -96,15 +96,14 @@
   display: none;
   position: fixed;
   top: 43px; // magic number to place under header
-  left: 0;
+  left: 3px; // allow shadow to fit on left size of rect
   z-index: 2;
-  width: 210px;
+  width: 207px;
   padding: 10px;
   border: 1px solid #555;
   background: rgba(0, 0, 0, .75);
   color: #ccc;
-  box-shadow: 0 0 0 0 3px rgba(0, 0, 0, .45);
-  border-radius: 3px;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, .45);
   pointer-events: none;
 
   .inventory-item:hover & {

--- a/inventory/src/sass/inventory.scss
+++ b/inventory/src/sass/inventory.scss
@@ -8,8 +8,11 @@
  @import "../../node_modules/camelot-unchained/lib/index.scss";
 
 #inventory {
-  width: 273px;
-  height: 336px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 250px;
 }
 
 .cu-window-content::before {
@@ -36,7 +39,7 @@
   text-shadow: -1px -1px 1px #000, 1px -1px 1px #000, -1px 1px 1px #000, 1px 1px 1px #000;
 
   &:hover {
-    background-color: rgba(0,0,0,0.5);
+    background-color: rgba(0,0,0,0.75);
   }
 
   .inventory-list--vertical & {
@@ -91,16 +94,17 @@
 
 .tooltip {
   display: none;
-  position: absolute;
-  bottom: 100%;
+  position: fixed;
+  top: 42px; // magic number to place under header
   left: 0;
   z-index: 2;
-  width: 100%;
+  width: 250px;
   padding: 10px;
   border: 1px solid #555;
   background: rgba(0, 0, 0, .75);
   color: #ccc;
   box-shadow: 0 0 0 0 3px rgba(0, 0, 0, .45);
+  border-radius: 3px;
   pointer-events: none;
 
   .inventory-item:hover & {
@@ -109,9 +113,15 @@
 }
 
 .tooltip__title {
-  font-size: 14px;
+  margin: 0 0 3px;
+  font-size: 13px;
   font-weight: 600;
   color: #fff;
+}
+
+.tooltip__detail {
+  margin: 0 0 4px;
+  font-size: 10px;
 }
 
 .tooltip__meta {

--- a/inventory/src/sass/inventory.scss
+++ b/inventory/src/sass/inventory.scss
@@ -79,7 +79,6 @@
   }
 }
 
-
 ::-webkit-scrollbar {
   width: 8px;
 }

--- a/inventory/src/sass/inventory.scss
+++ b/inventory/src/sass/inventory.scss
@@ -129,7 +129,3 @@
   font-size: 9px;
   color: #999;
 }
-
-.cu-tooltip-inner {
-  padding: 2px 6px !important;
-}

--- a/inventory/src/sass/inventory.scss
+++ b/inventory/src/sass/inventory.scss
@@ -18,60 +18,62 @@
 
 .inventory-list {
   overflow: auto;
-  height: calc(100% - 50px);
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: 0;
+  padding: 4px 2px 0 5px;
   list-style: none;
-  padding-left: 5px;
-  padding-right: 2px;
-  padding-bottom: 0px;
-  padding-top: 4px;
-  li {
-    margin-bottom: 0px;
-    padding-left: 4px;
-    padding-right: 2px;
-    padding-top: 4px;
-    padding-bottom: 4px;
-    text-shadow: -1px -1px 1px #000, 1px -1px 1px #000, -1px 1px 1px #000, 1px 1px 1px #000;
-    &:hover {
-      background-color: rgba(0,0,0,0.5);
-    }
+}
+
+.inventory-item {
+  position: relative;
+  margin: 0px;
+  padding: 4px 2px;
+  text-shadow: -1px -1px 1px #000, 1px -1px 1px #000, -1px 1px 1px #000, 1px 1px 1px #000;
+
+  &:hover {
+    background-color: rgba(0,0,0,0.5);
   }
 
-  &.list-vertical {
-    li {
+  .inventory-list--vertical & {
+    overflow: hidden;
+    cursor: pointer;
+
+    .icon {
+      display: block;
+      float: left;
+
+      img {
+        display: block;
+      }
+    }
+
+    .name {
+      display: block;
+      float: left;
+      max-width: 190px;
+      padding-left: 5px;
+      line-height: 15px;
+      white-space: nowrap;
       overflow: hidden;
-      cursor: pointer;
-      .icon {
-        display: block;
-        float: left;
-        img {
-          display: block;
-        }
-      }
-      .name {
-        display: block;
-        float: left;
-        line-height: 15px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        max-width: 190px;
-        padding-left: 5px;
-        font-size: 80%;
-      }
-      .quantity {
-        display: block;
-        float: left;
-        line-height: 15px;
-        float: right;
-        line-height: 15px;
-        padding-left: 5px;
-        padding-right: 2px;
-        font-size: 80%;
-        text-align: right;
-      }
+      text-overflow: ellipsis;
+      font-size: 80%;
+    }
+
+    .quantity {
+      display: block;
+      float: right;
+      padding: 0 2px 0 5px;
+      line-height: 15px;
+      font-size: 80%;
+      text-align: right;
     }
   }
 }
+
 
 ::-webkit-scrollbar {
   width: 8px;
@@ -85,30 +87,45 @@
   -webkit-box-shadow: inset 0 0 10px #000;
 }
 
-.tooltip-content {
+.tooltip {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 230px;
+  pointer-events: none;
+
+  .inventory-item:hover & {
+    display: block;
+  }
+}
+
+.tooltip__content {
+  width: 100%;
+
   tr {
     font-size: 80%;
     vertical-align: top;
     border-bottom: 1px dashed #222;
+
     &:last-child {
       border-bottom: none;
     }
   }
+
   th {
-    padding-right: 5px;
+    padding: 2px 5px 2px 0;
     border-right: 1px dashed #222;
-    padding-bottom: 2px;
-    padding-top: 2px;
   }
+
   td {
-    padding-left: 5px;
-    padding-bottom: 2px;
-    padding-top: 2px;
+    padding: 2px 0 2px 5px;
     word-break: break-word;
+
     &.font-small {
       font-size: 9px;
     }
+
     &.font-monospace {
       font-family: 'Roboto Mono', monospace;
     }

--- a/inventory/src/ts/components/inventory-window.tsx
+++ b/inventory/src/ts/components/inventory-window.tsx
@@ -61,30 +61,10 @@ export class InventoryWindow extends React.Component<InventoryWindowProps, Inven
             <div className="icon"><img src="../../interface-lib/camelot-unchained/images/items/icon.png" /></div>
             <div className="name">{group.item.name}</div>
             <div className="tooltip">
-              <table className="cu-table tooltip__content">
-                <tbody>
-                  <tr>
-                    <th>Name</th>
-                    <td>{group.item.name}</td>
-                  </tr>
-                  <tr>
-                    <th>Description</th>
-                    <td>{group.item.description}</td>
-                  </tr>
-                  <tr>
-                    <th>Gear Slot</th>
-                    <td>{this.getGearSlotName(group.item.gearSlot)} ({group.item.gearSlot})</td>
-                  </tr>
-                  <tr>
-                    <th>Item ID</th>
-                    <td className="font-monospace font-small">{group.item.id}</td>
-                  </tr>
-                  <tr>
-                    <th>Resource ID</th>
-                    <td className="font-monospace">{group.item.resourceID}</td>
-                  </tr>
-                </tbody>
-              </table>
+              <h1 className="tooltip__title">{group.item.name}</h1>
+              <p className="tooltip__slot">{this.getGearSlotName(group.item.gearSlot)}</p>
+              <p className="tooltip__description">{group.item.description}</p>
+              <p className="tooltip__meta">{group.item.id}</p>
             </div>
           </li>
       ));

--- a/inventory/src/ts/components/inventory-window.tsx
+++ b/inventory/src/ts/components/inventory-window.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 import {client, events, Inventory, Item, gearSlot} from 'camelot-unchained';
 import ClassNames from 'classnames';
 import {ItemGroup} from './item-group';
-import Tooltip from 'rc-tooltip';
+// import Tooltip from 'rc-tooltip';
 
 export class InventoryWindow extends React.Component<InventoryWindowProps, InventoryWindowState> {
   private listener: any;
@@ -56,10 +56,36 @@ export class InventoryWindow extends React.Component<InventoryWindowProps, Inven
     this.state.itemGroups.forEach((group: ItemGroup, index: number) => {
       console.log(group);
       itemGroups.push((
-          <li key={'item-group' + index} onDoubleClick={this.useItem.bind(this, group) } onContextMenu={this.dropItem.bind(this, group )}>
+          <li className="inventory-item" key={'item-group' + index} onDoubleClick={this.useItem.bind(this, group) } onContextMenu={this.dropItem.bind(this, group )}>
             <div className="icon"><img src="../../interface-lib/camelot-unchained/images/items/icon.png" /></div>
             <div className="name">{group.item.name}</div>
             <div className="quantity">{group.quantity}</div>
+            <div className="tooltip">
+              <table className="cu-table tooltip__content">
+                <tbody>
+                  <tr>
+                    <th>Name</th>
+                    <td>{group.item.name}</td>
+                  </tr>
+                  <tr>
+                    <th>Description</th>
+                    <td>{group.item.description}</td>
+                  </tr>
+                  <tr>
+                    <th>Gear Slot</th>
+                    <td>{this.getGearSlotName(group.item.gearSlot)} ({group.item.gearSlot})</td>
+                  </tr>
+                  <tr>
+                    <th>Item ID</th>
+                    <td className="font-monospace font-small">{group.item.id}</td>
+                  </tr>
+                  <tr>
+                    <th>Resource ID</th>
+                    <td className="font-monospace">{group.item.resourceID}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </li>
       ));
     });
@@ -72,7 +98,7 @@ export class InventoryWindow extends React.Component<InventoryWindowProps, Inven
           </div>
         </div>
         <div className="cu-window-content">
-          <ul className="inventory-list list-vertical">
+          <ul className="inventory-list inventory-list--vertical">
             {itemGroups}
           </ul>
         </div>
@@ -80,34 +106,34 @@ export class InventoryWindow extends React.Component<InventoryWindowProps, Inven
     );
   }
 
-  renderTooltip(item: Item) {
-    return (
-      <table className="cu-table tooltip-content">
-        <tbody>
-          <tr>
-            <th>Name</th>
-            <td>{item.name}</td>
-          </tr>
-          <tr>
-            <th>Description</th>
-            <td>{item.description}</td>
-          </tr>
-          <tr>
-            <th>Gear Slot</th>
-            <td>{this.getGearSlotName(item.gearSlot)} ({item.gearSlot})</td>
-          </tr>
-          <tr>
-            <th>Item ID</th>
-            <td className="font-monospace font-small">{item.id}</td>
-          </tr>
-          <tr>
-            <th>Resource ID</th>
-            <td className="font-monospace">{item.resourceID}</td>
-          </tr>
-        </tbody>
-      </table>
-    );
-  }
+  // renderTooltip(item: Item) {
+  //   return (
+  //     <table className="cu-table tooltip-content">
+  //       <tbody>
+  //         <tr>
+  //           <th>Name</th>
+  //           <td>{item.name}</td>
+  //         </tr>
+  //         <tr>
+  //           <th>Description</th>
+  //           <td>{item.description}</td>
+  //         </tr>
+  //         <tr>
+  //           <th>Gear Slot</th>
+  //           <td>{this.getGearSlotName(item.gearSlot)} ({item.gearSlot})</td>
+  //         </tr>
+  //         <tr>
+  //           <th>Item ID</th>
+  //           <td className="font-monospace font-small">{item.id}</td>
+  //         </tr>
+  //         <tr>
+  //           <th>Resource ID</th>
+  //           <td className="font-monospace">{item.resourceID}</td>
+  //         </tr>
+  //       </tbody>
+  //     </table>
+  //   );
+  // }
 
   getGearSlotName(slot: gearSlot): string {
     switch (slot) {

--- a/inventory/src/ts/components/inventory-window.tsx
+++ b/inventory/src/ts/components/inventory-window.tsx
@@ -8,7 +8,6 @@ import * as React from 'react';
 import {client, events, Inventory, Item, gearSlot} from 'camelot-unchained';
 import ClassNames from 'classnames';
 import {ItemGroup} from './item-group';
-// import Tooltip from 'rc-tooltip';
 
 export class InventoryWindow extends React.Component<InventoryWindowProps, InventoryWindowState> {
   private listener: any;
@@ -62,9 +61,9 @@ export class InventoryWindow extends React.Component<InventoryWindowProps, Inven
             <div className="name">{group.item.name}</div>
             <div className="tooltip">
               <h1 className="tooltip__title">{group.item.name}</h1>
-              <p className="tooltip__slot">{this.getGearSlotName(group.item.gearSlot)}</p>
-              <p className="tooltip__description">{group.item.description}</p>
-              <p className="tooltip__meta">{group.item.id}</p>
+              <p className="tooltip__detail tooltip__slot">{this.getGearSlotName(group.item.gearSlot)}</p>
+              <p className="tooltip__detail tooltip__description">{group.item.description}</p>
+              <p className="tooltip__meta">Resource ID: {group.item.id}</p>
             </div>
           </li>
       ));
@@ -85,35 +84,6 @@ export class InventoryWindow extends React.Component<InventoryWindowProps, Inven
       </div>
     );
   }
-
-  // renderTooltip(item: Item) {
-  //   return (
-  //     <table className="cu-table tooltip-content">
-  //       <tbody>
-  //         <tr>
-  //           <th>Name</th>
-  //           <td>{item.name}</td>
-  //         </tr>
-  //         <tr>
-  //           <th>Description</th>
-  //           <td>{item.description}</td>
-  //         </tr>
-  //         <tr>
-  //           <th>Gear Slot</th>
-  //           <td>{this.getGearSlotName(item.gearSlot)} ({item.gearSlot})</td>
-  //         </tr>
-  //         <tr>
-  //           <th>Item ID</th>
-  //           <td className="font-monospace font-small">{item.id}</td>
-  //         </tr>
-  //         <tr>
-  //           <th>Resource ID</th>
-  //           <td className="font-monospace">{item.resourceID}</td>
-  //         </tr>
-  //       </tbody>
-  //     </table>
-  //   );
-  // }
 
   getGearSlotName(slot: gearSlot): string {
     switch (slot) {

--- a/inventory/src/ts/components/inventory-window.tsx
+++ b/inventory/src/ts/components/inventory-window.tsx
@@ -54,14 +54,13 @@ export class InventoryWindow extends React.Component<InventoryWindowProps, Inven
   render() {
     const itemGroups: JSX.Element[] = [];
     this.state.itemGroups.forEach((group: ItemGroup, index: number) => {
+      console.log(group);
       itemGroups.push((
-        <Tooltip placement="topLeft" key={'item-tooltip' + index} overlay={this.renderTooltip.call(this, group.item)} arrowContent={<div className="cu-tooltip-arrow-inner"></div>} prefixCls="cu-tooltip" mouseLeaveDelay={0} mouseEnterDelay={0.25}>
           <li key={'item-group' + index} onDoubleClick={this.useItem.bind(this, group) } onContextMenu={this.dropItem.bind(this, group )}>
             <div className="icon"><img src="../../interface-lib/camelot-unchained/images/items/icon.png" /></div>
             <div className="name">{group.item.name}</div>
             <div className="quantity">{group.quantity}</div>
           </li>
-        </Tooltip>
       ));
     });
     return (

--- a/inventory/src/ts/components/inventory-window.tsx
+++ b/inventory/src/ts/components/inventory-window.tsx
@@ -53,7 +53,6 @@ export class InventoryWindow extends React.Component<InventoryWindowProps, Inven
   render() {
     const itemGroups: JSX.Element[] = [];
     this.state.itemGroups.forEach((group: ItemGroup, index: number) => {
-      console.log(group);
       itemGroups.push((
           <li className="inventory-item" key={'item-group' + index} onDoubleClick={this.useItem.bind(this, group) } onContextMenu={this.dropItem.bind(this, group )}>
             <div className="quantity">{group.quantity}</div>

--- a/inventory/src/ts/components/inventory-window.tsx
+++ b/inventory/src/ts/components/inventory-window.tsx
@@ -57,9 +57,9 @@ export class InventoryWindow extends React.Component<InventoryWindowProps, Inven
       console.log(group);
       itemGroups.push((
           <li className="inventory-item" key={'item-group' + index} onDoubleClick={this.useItem.bind(this, group) } onContextMenu={this.dropItem.bind(this, group )}>
+            <div className="quantity">{group.quantity}</div>
             <div className="icon"><img src="../../interface-lib/camelot-unchained/images/items/icon.png" /></div>
             <div className="name">{group.item.name}</div>
-            <div className="quantity">{group.quantity}</div>
             <div className="tooltip">
               <table className="cu-table tooltip__content">
                 <tbody>

--- a/inventory/src/ts/components/inventory-window.tsx
+++ b/inventory/src/ts/components/inventory-window.tsx
@@ -54,13 +54,14 @@ export class InventoryWindow extends React.Component<InventoryWindowProps, Inven
   render() {
     const itemGroups: JSX.Element[] = [];
     this.state.itemGroups.forEach((group: ItemGroup, index: number) => {
-      console.log(group);
       itemGroups.push((
+        <Tooltip placement="topLeft" key={'item-tooltip' + index} overlay={this.renderTooltip.call(this, group.item)} arrowContent={<div className="cu-tooltip-arrow-inner"></div>} prefixCls="cu-tooltip" mouseLeaveDelay={0} mouseEnterDelay={0.25}>
           <li key={'item-group' + index} onDoubleClick={this.useItem.bind(this, group) } onContextMenu={this.dropItem.bind(this, group )}>
             <div className="icon"><img src="../../interface-lib/camelot-unchained/images/items/icon.png" /></div>
             <div className="name">{group.item.name}</div>
             <div className="quantity">{group.quantity}</div>
           </li>
+        </Tooltip>
       ));
     });
     return (

--- a/inventory/src/ts/components/inventory-window.tsx
+++ b/inventory/src/ts/components/inventory-window.tsx
@@ -54,6 +54,7 @@ export class InventoryWindow extends React.Component<InventoryWindowProps, Inven
   render() {
     const itemGroups: JSX.Element[] = [];
     this.state.itemGroups.forEach((group: ItemGroup, index: number) => {
+      console.log(group);
       itemGroups.push((
           <li key={'item-group' + index} onDoubleClick={this.useItem.bind(this, group) } onContextMenu={this.dropItem.bind(this, group )}>
             <div className="icon"><img src="../../interface-lib/camelot-unchained/images/items/icon.png" /></div>


### PR DESCRIPTION
I built the tooltips in a fixed position outside of the windows, on the left side. This creates a simple, predictable position for each tooltip, with plenty of room to add content (e.g., stats).

The broken rc-tooltip dependency and associated code were removed. There are also several CSS code style related cleanups, as well as introducing some BEM patterns to the markup.